### PR TITLE
Adding consul ACL support via environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Usage
     $ consul-do
     Usage: consul-do KEY NODE [DEBUG]
 
-    To use an ACL, export CONSUL_ACL_TOKEN=<your ACL token>
+    To use a consul ACL, export CONSUL_ACL_TOKEN=<your ACL token> in your environment prior to running the command.
 
 Useful for running cronjobs in HA mode.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Usage
     $ consul-do
     Usage: consul-do KEY NODE [DEBUG]
 
-    To use a consul ACL, export CONSUL_ACL_TOKEN=<your ACL token> in your environment prior to running the command.
+To use a consul ACL, export CONSUL_ACL_TOKEN=<your ACL token> in your environment prior to running the command.
 
 Useful for running cronjobs in HA mode.
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Usage
     $ consul-do
     Usage: consul-do KEY NODE [DEBUG]
 
-To use a consul ACL, export CONSUL_ACL_TOKEN=<your ACL token> in your environment prior to running the command.
-
 Useful for running cronjobs in HA mode.
 
 Run something like this on two or more servers:
@@ -35,6 +33,11 @@ To enable debug mode, add anything as a third argument. E.g.
     Found session: e32c055d-c6ed-e277-45ad-079ba218bb01
     Found session node, we're the leader
     ....
+
+If you require a consul ACL
+
+    $ CONSUL_ACL_TOKEN="mynicelongacltoken" consul-do ... 
+
 
 Testing
 =======

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Usage
     $ consul-do
     Usage: consul-do KEY NODE [DEBUG]
 
+    To use an ACL, export CONSUL_ACL_TOKEN=<your ACL token>
+
 Useful for running cronjobs in HA mode.
 
 Run something like this on two or more servers:

--- a/consul-do
+++ b/consul-do
@@ -1,10 +1,20 @@
 #!/usr/bin/env python
-import urllib2, json, base64, sys, time
+import urllib2, json, base64, os, sys, time
+
+def has_consul_token():
+  return "CONSUL_ACL_TOKEN" in os.environ
+
+def get_consul_token():
+  return os.environ.get('CONSUL_ACL_TOKEN')
 
 def url_put_json(url, data):
   opener = urllib2.build_opener(urllib2.HTTPHandler)
   request = urllib2.Request(url, data)
   request.add_header('Content-Type', 'application/json')
+
+  if has_consul_token():
+    request.add_header('X-Consul-Token', get_consul_token())
+
   request.get_method = lambda: 'PUT'
   return opener.open(request).read()
 
@@ -32,7 +42,12 @@ class ConsulDo:
   def get_store(self):
     url = "%s/v1/kv/service/%s/leader" % (self.base_url, self.key)
     try:
-      response = urllib2.urlopen(url).read()
+      if has_consul_token():
+        headers = {'X-Consul-Token': get_consul_token()}
+        req = urllib2.Request(url, None, headers)
+        response = urllib2.urlopen(req).read()
+      else:
+        response = urllib2.urlopen(url).read()
     except urllib2.HTTPError, e:
       if e.code == 404:
         return self.KV_MISSING


### PR DESCRIPTION
Hey zeroXten, 

I love your consul-do script, thanks for making it freely available.  Since the advent of ACL's I needed it to provide one when talking to consul.  This is my quick hack to add support for it.  It simply looks in the environment for a variable named CONSUL_ACL_TOKEN and will use it.   If you prefer to do it a different way ... change away.   This worked for me and I thought I would provide it back to you! 

[gneill794@myhost consul]$ unset CONSUL_ACL_TOKEN 
[gneill794@myhost consul]$ ./consul-do GNEILL794 $(hostname) debug 
Running...
Could not read KV store

[gneill794@myhost consul]$ CONSUL_ACL_TOKEN="mytoken" ./consul-do GNEILL794 $(hostname) debug && echo GNEILL794
Running...
Found KV store
Found session: cf8a4655-5c2d-e642-1897-15e422173d42
Found session node, we're the leader
GNEILL794

