### PR TITLE
Proper ACL environment variable for consul.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,22 @@ Usage
 =====
 
     $ consul-do
-    Usage: consul-do KEY NODE [DEBUG]
+    Usage: consul-do KEY [DEBUG]
 
 Useful for running cronjobs in HA mode.
 
 Run something like this on two or more servers:
 
-    * * * * * /usr/bin/consul-do JOB-1 $(/bin/hostname) && /path/to/job1
-    */10 * * * * /usr/bin/consul-do JOB-2 $(/bin/hostname) && /path/to/job2
+    *    * * * * /usr/bin/consul-do JOB-1 && /path/to/job1
+    */10 * * * * /usr/bin/consul-do JOB-2 && /path/to/job2
 
 Only one of the servers will be elected leader and will therefore run the job. Should the leader fail, a follower will take over.
 
-To enable debug mode, add anything as a third argument. E.g.
+To enable debug mode, add anything as a second argument. E.g.
 
-    $ consul-do JOB-1 $(hostname) debug
+    $ consul-do JOB-1 debug
     Running...
+    Found nodename: test.internal
     Found KV store
     Found session: e32c055d-c6ed-e277-45ad-079ba218bb01
     Found session node, we're the leader
@@ -52,6 +53,4 @@ Run the following on each respective server
 
 Now you can run a command on each server
 
-    $ while true; do /vagrant/consul-do testing $(hostname) && date; sleep 10; done
-
-
+    $ while true; do /vagrant/consul-do testing && date; sleep 10; done

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ See https://consul.io
 Installation
 ============
 
-It's just a python script with no additional modules. Download it and stick it somewhere.
+It's just a python script with no additional modules. Download it and stick it somewhere.  
+
+*NOTE* A consul agent is required to be installed where you run this script.
 
 Usage
 =====

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To enable debug mode, add anything as a third argument. E.g.
 
 If you require a consul ACL
 
-    $ CONSUL_ACL_TOKEN="mynicelongacltoken" consul-do ... 
+    $ CONSUL_HTTP_TOKEN="mytoken" consul-do ... 
 
 
 Testing

--- a/consul-do
+++ b/consul-do
@@ -40,6 +40,15 @@ class ConsulDo:
     if self.debug:
       print message
 
+  def get_node_name(self):
+    url = "%s/v1/agent/self" % self.base_url
+    request = urllib2.Request(url)
+    if has_consul_token():
+      request.add_header('X-Consul-Token', get_consul_token())
+    response = urllib2.urlopen(request).read()
+    data = json.loads(response)
+    return data['Config']['NodeName']
+
   def get_store(self):
     url = "%s/v1/kv/service/%s/leader" % (self.base_url, self.key)
     try:
@@ -109,6 +118,9 @@ class ConsulDo:
 
   def run(self):
     self.log("Running...")
+    self.node = self.get_node_name()
+    self.log("Found nodename: %s" % self.node)
+
     r = self.get_store()
     if r == self.KV_FOUND:
       self.log("Found KV store")
@@ -118,7 +130,7 @@ class ConsulDo:
           self.log("Found session node, we're the leader")
           sys.exit(self.RUN)
         else:
-          self.log("Found session node, we're not the leader")
+          self.log("Found session node, but %s is the leader" % self.session_node)
           sys.exit(self.SKIP)
       else:
         self.log("No session found")
@@ -133,12 +145,12 @@ class ConsulDo:
 
 if __name__ == '__main__':
   c = ConsulDo()
-  if len(sys.argv) < 3:
+  if len(sys.argv) < 2:
     print "Usage: consul-do KEY NODE [DEBUG]"
     sys.exit(1)
 
   c.key = sys.argv[1]
-  c.node = sys.argv[2]
-  if len(sys.argv) >= 4:
+
+  if len(sys.argv) >= 3:
     c.debug = True
   c.run()

--- a/consul-do
+++ b/consul-do
@@ -34,6 +34,7 @@ class ConsulDo:
     self.session = ""
     self.session_node = ""
     self.debug = False
+    self.session_parms = {}
 
   def log(self, message):
     if self.debug:
@@ -68,7 +69,13 @@ class ConsulDo:
     url = "%s/v1/session/create" % self.base_url
     try:
       self.log("Creating session")
-      response = url_put_json(url, None)
+      self.session_parms['LockDelay'] = '30s'
+      self.session_parms['Behavior'] = 'release' # default
+### if a session TTL is warranted, this is where it belongs. 
+### I am not convinced this is a 'good' thing.  I believe it
+### will possibly break the intention of the distributed lock.
+#      self.session_parms['TTL'] = '30s' 
+      response = url_put_json(url, json.dumps(self.session_parms))
     except Exception as e:
       self.log("Could not create session: %s" % str(e))
       sys.exit(self.SKIP)

--- a/consul-do
+++ b/consul-do
@@ -2,10 +2,10 @@
 import urllib2, json, base64, os, sys, time
 
 def has_consul_token():
-  return "CONSUL_ACL_TOKEN" in os.environ
+  return "CONSUL_HTTP_TOKEN" in os.environ
 
 def get_consul_token():
-  return os.environ.get('CONSUL_ACL_TOKEN')
+  return os.environ.get('CONSUL_HTTP_TOKEN')
 
 def url_put_json(url, data):
   opener = urllib2.build_opener(urllib2.HTTPHandler)


### PR DESCRIPTION
Hi zeroXten, 

I have one more patch.   It has two different items in it ... 

1) After further research it seems the "proper" environment variable to use for an ACL token is CONSUL_HTTP_TOKEN.    (see this reference, https://www.consul.io/docs/commands/index.html and search for the token) 

2) I set a couple of defaults for the creation of the session.   'lock-delay' and 'behavior'

   a) lock-delay  

> The final nuance is that sessions may provide a lock-delay. This is a time duration, between 0 and 60 seconds. When a session invalidation takes place, Consul prevents any of the previously held locks from being re-acquired for the lock-delay interval; this is a safeguard inspired by Google's Chubby. The purpose of this delay is to allow the potentially still live leader to detect the invalidation and stop processing requests that may lead to inconsistent state. While not a bulletproof method, it does avoid the need to introduce sleep states into application logic and can help mitigate many issues. While the default is to use a 15 second delay, clients are able to disable this mechanism by providing a zero delay value.

  b)  behavior  (I just specified the default) 

> When a session is invalidated, it is destroyed and can no longer be used. What happens to the associated locks depends on the behavior specified at creation time. Consul supports a release and delete behavior. The release behavior is the default if none is specified.

  c) ttl,   I updated an 'issue' on your github site.   I am not entirely sure adding the TTL option would be a 'good' thing.   However I did put it in this patch, but it's commented out.   I believe it could defeat the purpose of gaining the lock in the first place, further research is needed. 

> If the TTL interval expires without being renewed, the session has expired and an invalidation is triggered. This type of failure detector is also known as a heartbeat failure detector. It is less scalable than the gossip based failure detector as it places an increased burden on the servers but may be applicable in some cases. The contract of a TTL is that it represents a lower bound for invalidation; that is, Consul will not expire the session before the TTL is reached, but it is allowed to delay the expiration past the TTL. The TTL is renewed on session creation, on session renew, and on leader failover. When a TTL is being used, clients should be aware of clock skew issues: namely, time may not progress at the same rate on the client as on the Consul servers. It is best to set conservative TTL values and to renew in advance of the TTL to account for network delay and time skew.

TIA,
George.
 


